### PR TITLE
changes for filter bot toggle

### DIFF
--- a/collections/brandedColleges.js
+++ b/collections/brandedColleges.js
@@ -23,4 +23,5 @@ BrandedColleges.attachSchema(new SimpleSchema({
   linkTourSignUp: {type: String, optional: true}, 
   linkVisitTips: {type: String, optional: true}, 
   phoneFinAid: {type: String, optional: true}, 
+  filterOn: {type: Boolean, optional: true}
 }));

--- a/collections/georgiaStateUsers.js
+++ b/collections/georgiaStateUsers.js
@@ -38,6 +38,7 @@ BrandedUserSchema = new SimpleSchema({
   }), optional: true},
   profile: {type: new SimpleSchema({
     studentType: fields.student_type(o),
+    studentCategory: fields.student_category(o),
     citizenVerified: fields.bool(o),
     immunizationHold: fields.bool(o),
     emergencyContactHold: fields.bool(o)

--- a/lib/_fields.js
+++ b/lib/_fields.js
@@ -362,6 +362,10 @@ var fieldDefs = {
     type: String,
     allowedValues: ["Freshman", "Dual Enrollment", "Non-Degree","Non-Traditional" ,"Postbaccalaureate", "Transfer", "Transient", "Unknown", "Continuing or Returning", "Intl Exchange Student", "Joint Enrollment", "Program for Excellence", "GSU-62"]
   },
+  student_category: {
+    type: String,
+    allowedValues: ["prospect","applicant","admit","enrolled","dropout", "alumni"]
+  },
   preference_type: {
     type: String,
     allowedValues: ["Residence hall", "Off-campus", "Parents", "Married housing", "Fraternity/Sorority"]


### PR DESCRIPTION
- new field in brandedColleges to toggle on filterBot (which keeps students from interacting with bot)
- new field for student category which tells us what type of student (prospect, alum, enrolled etc)
