### PR TITLE
AH-264: Add fields on schools for internal analyitics classification.

### DIFF
--- a/collections/brandedColleges.js
+++ b/collections/brandedColleges.js
@@ -7,6 +7,7 @@ BrandedColleges.attachSchema(new SimpleSchema({
   primaryBrandColor: {type: String, optional: true},
   aiSubject: {type: String},
   animal: {type: String, optional: true}, // Panther
+  botType: {type: [String], optional: true}, // for analysis; see AH-264
   collection: {type: String, optional: true},
   collegeId: {type: String, regEx: SimpleSchema.RegEx.Id, optional: true},
   counselors: {type: [Object], blackbox: true, optional: true, defaultValue: []},
@@ -31,6 +32,7 @@ BrandedColleges.attachSchema(new SimpleSchema({
   filterOn: {type: Boolean, optional: true},
   hashtag: {type: String, optional: true}, // include the hash
   infoGatheringBot: {type: String, optional: true}, //dialog scheduled after the initial dialog in an open bot
+  institutionType: {type: String, optional: true}, // for analysis; see AH-264
   intentDeadline: {type: Date, optional: true}, // june 1
   internalFieldMapping: {type: Object, blackbox: true, optional: true, defaultValue: {}},
   introKnownProspectBotPhoto: {type: String, optional: true, defaultValue: ''},
@@ -48,6 +50,7 @@ BrandedColleges.attachSchema(new SimpleSchema({
   mediaCongrats: {type: String, optional: true},
   mediaMascot: {type: String, optional: true},
   messagingServiceSid: {type: String, optional: true},
+  messagingType: {type: [String], optional: true}, // for analysis; see AH-264
   name: {type: String},
   oliName: {type: String},
   passwordConstraints: {type: [Object], optional: true, defaultValue: []},


### PR DESCRIPTION
AFAICT, this is all that's necessary to add the fields in Mongo.  I assume we'll be populating them ad-hoc for now.

[Link to the ticket](https://admithubteam.atlassian.net/browse/AH-264), for your convenience.