### PR TITLE
AH-443: Add `messages.prefix` field to brandedApplicantConversations.

### DIFF
--- a/collections/brandedApplicantConversations.js
+++ b/collections/brandedApplicantConversations.js
@@ -9,6 +9,7 @@ BrandedApplicantConversations.attachSchema(new SimpleSchema({
   messages: {type: [Object]},
   handled: {type: Boolean, optional: true, defaultValue: false},
   'messages.$.body': {type: String},
+  'messages.$.prefix': {type: String},
   'messages.$.created': {type: Date},
   'messages.$.auto': {type: Boolean, optional: true},
   'messages.$.email': {type: String, optional: true},


### PR DESCRIPTION
We use this to log the prefix added to the message by the Phoenix/Mascot
user.