### PR TITLE
Document BAC.messages.$.prefix and make it optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Fields:
   - `applicantId` Type: String. Required. **Deprecated**. This was the `_id` on the `brandedApplicants` document corresponding to the user. it is now identical to the `userId` -- i.e., it is the `_id` of the `brandedUserProfile` document of the relevant student user. I think it is non-functional. (To do: eliminate this.)
   - `messages`: Type: \[Object\]. Required. An array containing object that record information about the messages exchanges between the student user and the institution. Subfields:
     - `body` Type: String. Required. The text of the message.
+    - `prefix` Type: String. Optional. For escalation e-mails, the text of the introductory message added by the Phoenix/Mascot user or sensitive-topic auto-escalator.
     - `created` Type: Date. Required. Date the message was created. (To do: change name to `createdAt`.)
     - `sender` Type: String. Required. Allowed values: `student`, `college`, `admithub`. Indicates the source of the message.
     - `auto` Type: Boolean. Optional. Indicates whether the email was auto-generated becaue of the topic returned by Holocene. (To do: make this required.)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Fields:
   - `applicantId` Type: String. Required. **Deprecated**. This was the `_id` on the `brandedApplicants` document corresponding to the user. it is now identical to the `userId` -- i.e., it is the `_id` of the `brandedUserProfile` document of the relevant student user. I think it is non-functional. (To do: eliminate this.)
   - `messages`: Type: \[Object\]. Required. An array containing object that record information about the messages exchanges between the student user and the institution. Subfields:
     - `body` Type: String. Required. The text of the message.
-    - `prefix` Type: String. Optional. For escalation e-mails, the text of the introductory message added by the Phoenix/Mascot user or sensitive-topic auto-escalator.
+    - `prefix` Type: String. Optional. For escalation e-mails, the text of the introductory message added by the Phoenix/Mascot user or sensitive-topic auto-escalator.  Empty for responses from school users.
     - `created` Type: Date. Required. Date the message was created. (To do: change name to `createdAt`.)
     - `sender` Type: String. Required. Allowed values: `student`, `college`, `admithub`. Indicates the source of the message.
     - `auto` Type: Boolean. Optional. Indicates whether the email was auto-generated becaue of the topic returned by Holocene. (To do: make this required.)

--- a/collections/brandedApplicantConversations.js
+++ b/collections/brandedApplicantConversations.js
@@ -9,7 +9,7 @@ BrandedApplicantConversations.attachSchema(new SimpleSchema({
   messages: {type: [Object]},
   handled: {type: Boolean, optional: true, defaultValue: false},
   'messages.$.body': {type: String},
-  'messages.$.prefix': {type: String},
+  'messages.$.prefix': {type: String, optional: true}, // Only applies to escalations from Mascot/Phoenix
   'messages.$.created': {type: Date},
   'messages.$.auto': {type: Boolean, optional: true},
   'messages.$.email': {type: String, optional: true},


### PR DESCRIPTION
Forgot that this only applies to a subset of the brandedApplicantConversations (specifically those that represent escalation e-mails), so the field should be optional.

Also forgot to add it to the README.