### PR TITLE
AH-96 add holocene-context related fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Fields:
     - `depositPaid` Type: Boolean. Optional. Indicates whether or not a student has paid a deposit for their housing.
     - `onCampus` Type: Boolean. Optional. Indicates student lives on campus.
     - `preferenceType` Type: String. Optional. Allowed values: 'Residence hall', 'Off-campus', 'Parents', 'Married housing', 'Fraternity/Sorority'. Indicates the preffered living arrangment of the student.
+  - `holoceneContext` Type: Object. Optional. Used to store context values returned by Holocene, which we send back to Holocene in the event the contact asks another question, within a certain time limit. Subfields:
+    - `currentContext` Type: \[String\]. Required. The contexts returned by Holocene.
+    - `lastMessageDate` Type: Date. Required. The data at which the `currentContext` was last set. This is automatically set by the `before.update` hook.
   - `importData` Type: Object. Optional. Default value: empty object. Black-box. Used by astronomer and the brookline user creation endpoint for any unmapped data. (To do: determine if there is any need for this default value.)
   - `importSegmentLabels` Type: \[String\]. Optional. Default value: empty array. List of labels used to identify a batch of students imported on a single occasion. For each time the student is imported, there is a string in the `importSegmentLabels` array, and vice-versa.
   - `inStateStudent` Type: Boolean. Optional. Indicates if the student counts as "in-state" for the purposes of enrollment and tuition.

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Contains information concerning points of contact at client institutions. Fields
 ### Dialogs
 A document defining the general properties of a specific, scripted interaction with users. Fields:
   - `initialState` Type: String. Required. The `_id` of the `DialogState` document corresponding to the first state of this dialog. (To do: enforce simple-schema id syntax of value.)
+  - `contexts` Type: \[String\]. Required. Default value: `[]`. Values to be sent to Holocene as part of the context input, when a contact makes a query and is in a state that belongs to this dialog.
   - `converted` Type: Boolean. Optional. Indictes that the dialog was converted from an old workflow by script. (To do: establish that there is no sepcial problem with these workflows, then get rid of this field, if there is no reason to keep it.)
   - `createdAt` Type: Date. Optional. Date at which the dialog was created. (To do: make this required.)
   - `description` Type: String. Optional. Description of the dialog. Used for display on the front end, and for humans to comprehend what is going on. (To do: make this required.)
@@ -418,6 +419,7 @@ A document defining the general properties of a specific, scripted interaction w
 
 ### DialogStates
 Contains information about specific states in the associated dialogs state-graph. A user moves through the dialog by traersing a path through the graph. These graphs will usually be trees, but need not be. Fields:
+  - `contexts` Type: \[String\]. Required. Default value: `[]`. Values to be sent to Holocene as part of the context input, when a contact makes a query and is in this state.
   - `nextStates` Type: Object. Required. Black box. Indicates the successor states to the current state, and provides information about which state to go to next. (To do: un-black-box this.)
   - `parentDialog` Type: String. Required. The `_id` of the `Dialog` document associated with this state. (To do: enforce simple-schema id syntax.)
   - `promptType` Type: String. Required. The type of reponse, if any, the state expects from the user. (To do: enforce allowed values: `Number`, `Open`, `Auto` and `Boolean`. Change name to `type`.)

--- a/collections/brandedUserProfile.js
+++ b/collections/brandedUserProfile.js
@@ -374,13 +374,15 @@ BrandedUserSchema = new SimpleSchema({
 BrandedUserProfiles = new Mongo.Collection('brandedUserProfiles')
 BrandedUserProfiles.attachSchema(BrandedUserSchema)
 
-const DATED_FIELDS = {
+const AUTO_DATED_FIELDS = {
+  // Fields for which we record the date they were last set.
+  // Key is the field we're recording information about, value is the field where the information is recorded.
   '_contactSettings.canText': '_contactSettings.canTextLastModified',
   'holoceneContext.currentContext': 'holoceneContext.lastMessageDate'
 }
 
 BrandedUserProfiles.before.update((userId, doc, fieldNames, modifier) => {
-  Object.entries(DATED_FIELDS).forEach(([key, value]) => {
+  Object.entries(AUTO_DATED_FIELDS).forEach(([key, value]) => {
     if (modifier.$set && modifier.$set[key] !== undefined) { modifier.$set[value] = new Date() }
   })
 })

--- a/collections/brandedUserProfile.js
+++ b/collections/brandedUserProfile.js
@@ -8,8 +8,10 @@ GeorgiaSchema = {type: new SimpleSchema({
     qualified: fields.bool(o),
     appReceived: fields.bool(o),
     accepted: fields.bool(o)
-  }), optional: true}
-}), optional: true}
+  }),
+  optional: true}
+}),
+optional: true}
 
 BrandedUserSchema = new SimpleSchema({
   '_id': {optional: true, type: null},
@@ -26,7 +28,8 @@ BrandedUserSchema = new SimpleSchema({
     appCompleteDate: fields.date(o),
     decisionDate: fields.date(o),
     applicationType: fields.string(o)
-  }), optional: true},
+  }),
+  optional: true},
   created: fields.date(),
   collegeName: fields.string(o),
   college: fields.string(o),
@@ -34,39 +37,50 @@ BrandedUserSchema = new SimpleSchema({
   control: fields.bool(o),
   dob: fields.date(o),
   email: fields.string(o),
-  enrollmentId: fields.string(o), //pantherId for gsu
+  enrollmentId: fields.string(o), // pantherId for gsu
   entryTerm: fields.string(o),
   entryYear: fields.number(o),
   facebookId: fields.string(o),
   facebookOptIn: fields.bool(o),
-  finAid: {type: new SimpleSchema({
-    fafsaReceived: fields.bool(o),
-    finAidComplete: fields.bool(o),
-    fafsaComplete: fields.bool(o),
-    finAidInterest: fields.bool(o),
-    scholarshipAwarded: fields.bool(o),
-    scholarshipAccepted: fields.bool(o),
-    acceptedOfferInternal: fields.bool(o),
-    offered: fields.bool(o),
-    entranceCounselingComplete: fields.bool(o),
-    mpnPerkinsComplete: fields.bool(o),
-    mpnStaffordPlusComplete: fields.bool(o),
-    acceptedFedLoan: fields.bool(o),
-    aidGap: fields.string(o),
-    fafsaVerificationFlagDate: fields.date(o),
-    fedLoanOffered: fields.bool(o),
-    pellAwardAmount: fields.string(o),
-    pellAwardDate: fields.date(o),
-    workstudyAmount: fields.string(o),
-    workstudtAwardDate: fields.date(o)
-  }), optional: true},
+  finAid: {
+    type: new SimpleSchema({
+      fafsaReceived: fields.bool(o),
+      finAidComplete: fields.bool(o),
+      fafsaComplete: fields.bool(o),
+      finAidInterest: fields.bool(o),
+      scholarshipAwarded: fields.bool(o),
+      scholarshipAccepted: fields.bool(o),
+      acceptedOfferInternal: fields.bool(o),
+      offered: fields.bool(o),
+      entranceCounselingComplete: fields.bool(o),
+      mpnPerkinsComplete: fields.bool(o),
+      mpnStaffordPlusComplete: fields.bool(o),
+      acceptedFedLoan: fields.bool(o),
+      aidGap: fields.string(o),
+      fafsaVerificationFlagDate: fields.date(o),
+      fedLoanOffered: fields.bool(o),
+      pellAwardAmount: fields.string(o),
+      pellAwardDate: fields.date(o),
+      workstudyAmount: fields.string(o),
+      workstudtAwardDate: fields.date(o)
+    }),
+    optional: true
+  },
   georgia: GeorgiaSchema,
+  holoceneContext: {
+    type: new SimpleSchema({
+      currentContext: {type: [String]},
+      lastMessageDate: fields.date()
+    }),
+    optional: true
+  },
   housing: {type: new SimpleSchema({
     onCampus: fields.bool(o),
     preferenceType: fields.preference_type(o),
     depositPaid: fields.bool(o),
     depositDate: fields.date(o)
-  }), optional: true},
+  }),
+  optional: true},
   importData: {
     type: Object,
     blackbox: true,
@@ -79,10 +93,12 @@ BrandedUserSchema = new SimpleSchema({
     intendsToEnroll: fields.bool(o),
     intentReceivedDate: fields.date(o),
     counselorCanContact: fields.bool(o)
-  }), optional: true},
+  }),
+  optional: true},
   interest: {type: new SimpleSchema({
     crm: fields.number({min: 0, max: 5, optional: true})
-  }), optional: true},
+  }),
+  optional: true},
   knownUser: {type: Boolean, optional: true},
   _testUser: {type: Boolean, optional: true},
   lastIntegrationDate: fields.date(o),
@@ -95,7 +111,8 @@ BrandedUserSchema = new SimpleSchema({
     state: fields.state(o),
     zip: fields.zip_code(_.extend(o)),
     country: fields.string(o)
-  }), optional: true},
+  }),
+  optional: true},
   meta: {
     type: Object,
     blackbox: true,
@@ -107,13 +124,15 @@ BrandedUserSchema = new SimpleSchema({
     middleName: fields.string(o),
     full: fields.string(o),
     nickName: fields.string(o)
-  }), optional: true},
+  }),
+  optional: true},
   orientation: {type: new SimpleSchema({
     needsToRsvp: fields.bool(o),
     attended: fields.bool(o),
     attendedDate: fields.date(o),
     registeredDate: fields.date(o)
-  }), optional: true},
+  }),
+  optional: true},
   permittedUser: fields.bool(o),
   phone: fields.string(o),
   presumedState: {type: new SimpleSchema({
@@ -123,7 +142,8 @@ BrandedUserSchema = new SimpleSchema({
     orientationAttendedDate: fields.date(o), // orientation.attendedDate /
     orientationNeedsToRsvp: fields.bool(o), // orientation.needsToRsvp /
     intendsToEnroll: fields.bool(o) // intent.intendsToEnroll /
-  }), optional: true}, 
+  }),
+  optional: true},
   profile: {type: new SimpleSchema({
     studentType: fields.student_type(o),
     studentCategory: fields.student_category(o),
@@ -141,7 +161,8 @@ BrandedUserSchema = new SimpleSchema({
     residency: fields.string(o),
     honorsProspect: fields.bool(o),
     firstGen: fields.bool(o)
-  }), optional: true},
+  }),
+  optional: true},
   scholarBot: {type: Object, blackbox: true, optional: true},
   smsInfo: {type: Object, blackbox: true, optional: true, defaultValue: {}},
   schoolEmail: fields.email(o),
@@ -152,7 +173,8 @@ BrandedUserSchema = new SimpleSchema({
     third: fields.string(o),
     fourth: fields.string(o),
     fifth: fields.string(o)
-  }), optional: true},
+  }),
+  optional: true},
   tests: {type: new SimpleSchema({
     gpa: fields.number({decimal: true, optional: true}),
     maxGpa: fields.number({decimal: true, optional: true}),
@@ -172,15 +194,18 @@ BrandedUserSchema = new SimpleSchema({
     actDevAndSupport: fields.act_composite_score(o),
     actOrganization: fields.act_composite_score(o),
     actLangaugeConvention: fields.act_composite_score(o)
-  }), optional: true},
+  }),
+  optional: true},
   textSetting: {type: new SimpleSchema({
     canText: fields.bool(o),
     wrongNumber: fields.bool(o), // moved to user doc
     newPhone: fields.phone_number(o)
-  }), optional: true},
+  }),
+  optional: true},
   tuiton: {type: new SimpleSchema({
     paymentPlan: fields.bool(o)
-  }), optional: true},
+  }),
+  optional: true},
   withdrawalReason: fields.string(o),
   _aidLastPush: {type: new SimpleSchema({ // all internal._aidLast
     planSubmitFafsa: fields.bool(o), // all internal._aidLast
@@ -188,7 +213,8 @@ BrandedUserSchema = new SimpleSchema({
     planAttendOrientation: fields.bool(o), // all internal._aidLast
     allSetHousing: fields.bool(o), // all internal._aidLast
     unableToMakePayment: fields.bool(o) // all internal._aidLast
-  }), optional: true},
+  }),
+  optional: true},
   _contactSettings: {type: new SimpleSchema({
     canMessageGeneral: fields.bool(o),
     canMessageFacebook: fields.bool(o),
@@ -205,7 +231,8 @@ BrandedUserSchema = new SimpleSchema({
     twilioLookUpValid: fields.bool(o),
     passiveOptOut: fields.bool(o),
     carrier: fields.string(o)
-  }), optional: true},
+  }),
+  optional: true},
   _custom: {
     type: Object,
     blackbox: true,
@@ -218,7 +245,8 @@ BrandedUserSchema = new SimpleSchema({
     finAidInterest: fields.bool(o),
     gapInAid: fields.bool(o), // _internal.gapInAid
     needHelpPaying: fields.bool(o) // _internal.needHelpPaying
-  }), optional: true},
+  }),
+  optional: true},
   _finalStudySurveyBot: {type: new SimpleSchema({
     enrollmentHowHard: fields.string(o),
     textHowHelpful: fields.string(o),
@@ -233,7 +261,8 @@ BrandedUserSchema = new SimpleSchema({
     whyNoResponse: fields.long_string(o),
     didYouRead: fields.bool(o),
     whyNoText: fields.long_string(o)
-  }), optional: true},
+  }),
+  optional: true},
   _gather: {type: new SimpleSchema({
     firstName: fields.string(o),
     lastName: fields.string(o),
@@ -265,21 +294,25 @@ BrandedUserSchema = new SimpleSchema({
     actDevAndSupport: fields.act_composite_score(o),
     actOrganization: fields.act_composite_score(o),
     actLangaugeConvention: fields.act_composite_score(o)
-  }), optional: true},
+  }),
+  optional: true},
   _general: {type: new SimpleSchema({
     secondGroup: fields.bool(o), // internal.secondGroup
     whyNotTexting: fields.string(o) // internal.whyNotTexting
-  }), optional: true},
+  }),
+  optional: true},
   _housing: {type: new SimpleSchema({
     intention: fields.string(o) // _internal.housingResponse
-  }), optional: true},
+  }),
+  optional: true},
   _intent: {type: new SimpleSchema({
     alreadySubmitted: fields.bool(o), // new
     coming: {type: new SimpleSchema({
       reasonCode: fields.number(o),
       secondChoiceSchool: fields.string(o),
       secondChoiceState: fields.string(o)
-    }), optional: true},
+    }),
+    optional: true},
     date: fields.date(o), // internal.intentDate
     followUpIntent: fields.attending(o), // internal./followUpIntent
     goingInstead: fields.long_string(o), // internal.goingInstead
@@ -289,7 +322,8 @@ BrandedUserSchema = new SimpleSchema({
       firstChoiceSchool: fields.string(o),
       firstChoiceState: fields.string(o),
       reasonCode: fields.number(o)
-    }), optional: true},
+    }),
+    optional: true},
     unsure: fields.bool(o), // internal.intentUnsure todo - mark this in unsure questions
     whyHere: fields.long_string(o), // internal.whyHere
     whyNoCollege: fields.string(o), // internal.whyNoCollege
@@ -297,7 +331,8 @@ BrandedUserSchema = new SimpleSchema({
     whyNotAttendingExtended: fields.long_string(o), // internal.whyNotAttendingExtended
     whyUnsure: fields.string(o), // was internal.whyUnsure
     whyUnsureExtended: fields.long_string(o) // was internal.whyUnsureExtended
-  }), optional: true},
+  }),
+  optional: true},
   _lastContacted: fields.date(o),
   _lastMessageId: fields.string(o),
   _lastTransport: fields.string(o),
@@ -314,10 +349,12 @@ BrandedUserSchema = new SimpleSchema({
     improvement: fields.long_string(o), // internal.orientation.improvement
     willYouAttend: fields.string(o), // internal.orientation.willYouAttend
     registered: fields.bool(o) // internal.registeredOrientation
-  }), optional: true},
+  }),
+  optional: true},
   _parking: {type: new SimpleSchema({
     bringCar: fields.bool(o) // _internal.needsParking
-  }), optional: true},
+  }),
+  optional: true},
   _phone: fields.string(o),
   _previousPhone: fields.string(o),
   _profile: {type: new SimpleSchema({
@@ -325,19 +362,25 @@ BrandedUserSchema = new SimpleSchema({
     parent: fields.bool(o),
     plannedApplication: fields.planned_application(o),
     setCanTextFalse: fields.bool(o)
-  }), optional: true},
+  }),
+  optional: true},
   _responseBlackBox: {
     type: Object,
     blackbox: true,
     optional: true
   }
-});
+})
 
 BrandedUserProfiles = new Mongo.Collection('brandedUserProfiles')
 BrandedUserProfiles.attachSchema(BrandedUserSchema)
 
+const DATED_FIELDS = {
+  '_contactSettings.canText': '_contactSettings.canTextLastModified',
+  'holoceneContext.currentContext': 'holoceneContext.lastMessageDate'
+}
+
 BrandedUserProfiles.before.update((userId, doc, fieldNames, modifier) => {
-  if (modifier.$set && modifier.$set['_contactSettings.canText'] !== undefined) {
-    modifier.$set['_contactSettings.canTextLastModified'] = new Date()
-  }
-});
+  Object.entries(DATED_FIELDS).forEach(([key, value]) => {
+    if (modifier.$set && modifier.$set[key] !== undefined) { modifier.$set[value] = new Date() }
+  })
+})

--- a/collections/dataWorkflows.js
+++ b/collections/dataWorkflows.js
@@ -6,46 +6,59 @@ Dialogs.attachSchema(new SimpleSchema({
   'humanName': {type: String, optional: true},
   'description': {type: String, optional: true},
   'messagingService': {type: String, optional: true},
+  'contexts': {type: [String], optional: true},
   'createdAt': {type: Date, optional: true},
   'updatedAt': {type: Date, optional: true},
   'hidden': {type: Boolean, optional: true},
   'sentToUsers': {type: Boolean, optional: true},
-  'initialState': {type: String , optional: false},
+  'initialState': {type: String, optional: false},
   'states': {type: [String], optional: true},
   'expirationLength': {type: Number, optional: true},
   'reminders': {type: [Object], blackbox: true, optional: true},
-  'converted': {type: Boolean, optional: true}, //a flag to show that the dialog was converted from a data workflow by script
+  'converted': {type: Boolean, optional: true}, // a flag to show that the dialog was converted from a data workflow by script
   'isIntro': {type: Boolean, optional: true, defaultValue: false},
-  'metadata': {type: new SimpleSchema({
-    'createdBy': {type: String, optional: false},
-    'createdVia': {type: String, optional: false}
-  }), optional: true}
+  'metadata': {
+    type: new SimpleSchema({
+      'createdBy': {type: String, optional: false},
+      'createdVia': {type: String, optional: false}
+    }),
+    optional: true
+  }
 }))
 
 DialogStates = new Mongo.Collection('dialogStates')
 
 DialogStates.attachSchema(new SimpleSchema({
   '_id': {type: String, optional: true},
+  'contexts': {type: [String], optional: true},
   'name': {type: String, optional: true},
   'promptType': {type: String, optional: false},
   'prompt': {type: String, optional: false, defaultValue: ''},
-  'skip': {type: new SimpleSchema({
+  'skip': {
+    type: new SimpleSchema({
       'query': {type: String}
-    }), optional: true
+    }),
+    optional: true
   },
   'media': {type: String, optional: true},
   'parentDialog': {type: String, optional: false},
   'nextStates': {type: Object, blackbox: true},
   'enterActions': {type: [Object], blackbox: true, optional: true},
   'exitActions': {type: [Object], blackbox: true, optional: true},
-  'range': {type: new SimpleSchema({
-    min: {type: Number, optional: false},
-    max: {type: Number, optional: false}
-  }), optional: true},
+  'range': {
+    type: new SimpleSchema({
+      min: {type: Number, optional: false},
+      max: {type: Number, optional: false}
+    }),
+    optional: true
+  },
   'openPromptLabel': {type: String, optional: true},
-  'multipleChoices': {type: [new SimpleSchema({
-    prompt: {type: String, optional: false}
-  })], optional: true},
+  'multipleChoices': {
+    type: [new SimpleSchema({
+      prompt: {type: String, optional: false}
+    })],
+    optional: true
+  },
   'pauseTime': {type: Number, optional: true},
   'converted': {type: String, optional: true},
   'createdAt': {type: Date, optional: true},

--- a/collections/dataWorkflows.js
+++ b/collections/dataWorkflows.js
@@ -2,21 +2,22 @@ Dialogs = new Mongo.Collection('dialogs')
 
 Dialogs.attachSchema(new SimpleSchema({
   '_id': {type: String, optional: true},
-  'name': {type: String, optional: true},
-  'humanName': {type: String, optional: true},
-  'description': {type: String, optional: true},
-  'messagingService': {type: String, optional: true},
-  'contexts': {type: [String], optional: true},
-  'createdAt': {type: Date, optional: true},
-  'updatedAt': {type: Date, optional: true},
-  'hidden': {type: Boolean, optional: true},
-  'sentToUsers': {type: Boolean, optional: true},
+  'contexts': {type: [String], optional: false, defaultValue: []},
   'initialState': {type: String, optional: false},
-  'states': {type: [String], optional: true},
-  'expirationLength': {type: Number, optional: true},
-  'reminders': {type: [Object], blackbox: true, optional: true},
+
   'converted': {type: Boolean, optional: true}, // a flag to show that the dialog was converted from a data workflow by script
+  'createdAt': {type: Date, optional: true},
+  'description': {type: String, optional: true},
+  'expirationLength': {type: Number, optional: true},
+  'hidden': {type: Boolean, optional: true},
+  'humanName': {type: String, optional: true},
   'isIntro': {type: Boolean, optional: true, defaultValue: false},
+  'messagingService': {type: String, optional: true},
+  'name': {type: String, optional: true},
+  'reminders': {type: [Object], blackbox: true, optional: true},
+  'sentToUsers': {type: Boolean, optional: true},
+  'states': {type: [String], optional: true},
+  'updatedAt': {type: Date, optional: true},
   'metadata': {
     type: new SimpleSchema({
       'createdBy': {type: String, optional: false},
@@ -30,21 +31,27 @@ DialogStates = new Mongo.Collection('dialogStates')
 
 DialogStates.attachSchema(new SimpleSchema({
   '_id': {type: String, optional: true},
-  'contexts': {type: [String], optional: true},
-  'name': {type: String, optional: true},
-  'promptType': {type: String, optional: false},
-  'prompt': {type: String, optional: false, defaultValue: ''},
-  'skip': {
-    type: new SimpleSchema({
-      'query': {type: String}
-    }),
-    optional: true
-  },
-  'media': {type: String, optional: true},
+  'contexts': {type: [String], optional: false, defaultValue: []},
   'parentDialog': {type: String, optional: false},
-  'nextStates': {type: Object, blackbox: true},
+  'prompt': {type: String, optional: false, defaultValue: ''},
+  'promptType': {type: String, optional: false},
+
+  'converted': {type: String, optional: true},
+  'createdAt': {type: Date, optional: true},
   'enterActions': {type: [Object], blackbox: true, optional: true},
   'exitActions': {type: [Object], blackbox: true, optional: true},
+  'name': {type: String, optional: true},
+  'media': {type: String, optional: true},
+  'multipleChoices': {
+    type: [new SimpleSchema({
+      prompt: {type: String, optional: false}
+    })],
+    optional: true
+  },
+  'nextStates': {type: Object, blackbox: true},
+  'openingAiResponseState': {type: Boolean, optional: true},
+  'openPromptLabel': {type: String, optional: true},
+  'pauseTime': {type: Number, optional: true},
   'range': {
     type: new SimpleSchema({
       min: {type: Number, optional: false},
@@ -52,16 +59,11 @@ DialogStates.attachSchema(new SimpleSchema({
     }),
     optional: true
   },
-  'openPromptLabel': {type: String, optional: true},
-  'multipleChoices': {
-    type: [new SimpleSchema({
-      prompt: {type: String, optional: false}
-    })],
+  'skip': {
+    type: new SimpleSchema({
+      'query': {type: String}
+    }),
     optional: true
   },
-  'pauseTime': {type: Number, optional: true},
-  'converted': {type: String, optional: true},
-  'createdAt': {type: Date, optional: true},
-  'updatedAt': {type: Date, optional: true},
-  'openingAiResponseState': {type: Boolean, optional: true}
+  'updatedAt': {type: Date, optional: true}
 }))


### PR DESCRIPTION
This is in preparation for a NeOlith PR related to AH-96, which restores input-context functionality.

The fields on brandedUserProfile are my idea; however, the fields on the Dialog and Dialog state documents are things that were already referred to in the code, but were missing from the schema. It appears that a feature related to input-contexts was half-finished before we launched NeOliTh; I'm in the process of finishing it as part of AH-96.

A lot of changes are just my auto-formatter; the field I added to brandedUserProfiles is `holoceneContext`. The fields I added to dialog and dialogState are both called `contexts`.

Note that I'm using the `before.update` hook on the BrandedUserProfile document to time-stamp changes to my new field; I generalised the code in that hook a little bit while I was at it.