### PR TITLE
AH-656 put `customInReports` boolean on `brandedColleges` document

### DIFF
--- a/collections/brandedColleges.js
+++ b/collections/brandedColleges.js
@@ -13,6 +13,7 @@ BrandedColleges.attachSchema(new SimpleSchema({
   collegeId: {type: String, regEx: SimpleSchema.RegEx.Id, optional: true},
   counselors: {type: [Object], blackbox: true, optional: true, defaultValue: []},
   csvTransformPipeline: {type: [String], optional: true, defaultValue: []},
+  customInReports: {type: Boolean, defaultValue: false},
   customQueryFields: {type: [String], optional: true, defaultValue: []},
   dateAccepted: {type: String, optional: true},
   dateScholarship: {type: String, optional: true},


### PR DESCRIPTION
A boolean that indicates whether an institution wants their custom fields to appear in reports they download in Mascot.

In preparation for a related PR on Marshall.