### PR TITLE
_fields: Allow url's to be 2000 characters.

### DIFF
--- a/lib/_fields.js
+++ b/lib/_fields.js
@@ -137,6 +137,10 @@ var fieldDefs = {
   url: {
     type: String,
     regEx: SimpleSchema.RegEx.Url,
+    /* In AH-802 we had an uexpected error due to the 200 character limit.
+     * Stackoverflow suggests that 2000 characters is a good upper bound:
+     * https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+    /*/
     max: 2000
   },
   address: {type: String},

--- a/lib/_fields.js
+++ b/lib/_fields.js
@@ -137,7 +137,7 @@ var fieldDefs = {
   url: {
     type: String,
     regEx: SimpleSchema.RegEx.Url,
-    /* In AH-802 we had an uexpected error due to the 200 character limit.
+    /* In AH-802 we had an unexpected error due to the 200 character limit.
      * Stackoverflow suggests that 2000 characters is a good upper bound:
      * https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
     /*/

--- a/lib/_fields.js
+++ b/lib/_fields.js
@@ -137,7 +137,7 @@ var fieldDefs = {
   url: {
     type: String,
     regEx: SimpleSchema.RegEx.Url,
-    max: 200
+    max: 2000
   },
   address: {type: String},
   state: {


### PR DESCRIPTION
Reference for the arbitary number:
https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers

Also, note that this submodule needs to be updated in neolith after this is merged.