### PR TITLE
AH-816 Give other facebook fields default values

### DIFF
--- a/collections/brandedColleges.js
+++ b/collections/brandedColleges.js
@@ -35,8 +35,8 @@ BrandedColleges.attachSchema(new SimpleSchema({
   emailPrefix: {type: String, optional: true},
   enabledFeatures: {type: [String], defaultValue: [], optional: true},
   facebook: {type: new SimpleSchema({
-    pageId: {type: String},
-    pageAccessToken: {type: String},
+    pageId: {type: String, defaultValue: ''},
+    pageAccessToken: {type: String, defaultValue: ''},
     subscriptionMessagingStatus: {type: String, defaultValue: 'not_yet_requested'}
   }),
   optional: true},


### PR DESCRIPTION
If you give a subfield a default value, it effectively makes the entire subdocument non-optional, so you need to give the other subfields in the subdocument default values. @edanaher was right to be worried about default values!