### PR TITLE
Revert "Remove subTransport field from confused merge."

### DIFF
--- a/collections/frozenSmslogs.js
+++ b/collections/frozenSmslogs.js
@@ -41,6 +41,7 @@ FrozenSmsLogs.attachSchema(new SimpleSchema({
   smsSid: {type: String, optional: true},
   source: {type: String, optional: true},
   sqsId: {type: String, optional: true}, // The AWS-SQS id associated with the message.
+  subTransport: {type: String, defaultValue: ''},
   testUser: {type: Boolean, optional: true, defaultValue: false},
   to: {type: String, optional: true},
   twilioErrorCode: {type: Number, optional: true},

--- a/collections/smslogs.js
+++ b/collections/smslogs.js
@@ -27,6 +27,9 @@ SmsLogs.attachSchema(new SimpleSchema({
   smsSid: {type: String, optional: true},
   source: {type: String, optional: true},
   sqsId: {type: String, optional: true}, // The AWS-SQS id associated with the message.
+  // For transports (i.e., channels) that have different points of ingress.
+  // Example: facebook messenger and the facebook web widgit.
+  subTransport: {type: String, defaultValue: ''},
   testUser: {type: Boolean, optional: true, defaultValue: false},
   to: {type: String, optional: true},
   twilioErrorCode: {type: Number, optional: true},


### PR DESCRIPTION
This reverts commit 4bf1206e7972b33519b9f0f3c64bccc9f89c2370.

Apparently this was supposed to be there.  *sigh*