### PR TITLE
AH-585 - add validation rule to _phone in BrandedUserProfile schema

### DIFF
--- a/collections/brandedUserProfile.js
+++ b/collections/brandedUserProfile.js
@@ -361,7 +361,8 @@ BrandedUserSchema = new SimpleSchema({
   optional: true},
   _phone: {
     type: String,
-    regEx: /^\d{10}$/
+    regEx: /^\d{10}$/,
+    optional: true
   },
   _previousPhone: fields.string(o),
   _profile: {type: new SimpleSchema({

--- a/collections/brandedUserProfile.js
+++ b/collections/brandedUserProfile.js
@@ -359,7 +359,10 @@ BrandedUserSchema = new SimpleSchema({
     bringCar: fields.bool(o) // _internal.needsParking
   }),
   optional: true},
-  _phone: fields.string(o),
+  _phone: {
+    type: String,
+    regEx: /^\d{10}$/
+  },
   _previousPhone: fields.string(o),
   _profile: {type: new SimpleSchema({
     description: fields.profile_description(o),


### PR DESCRIPTION
https://admithubteam.atlassian.net/browse/AH-585

I believe the only two ways phone numbers get added to the database are via Marshall and via Neolith if a student texts an open bot.

In Marshall, we have validation on the `phone` field here: https://github.com/AdmitHub/marshall/blob/9f219de871d883f6f90bdd11338b007f5cdf372f/backend/legacy/mongo.py#L1578

We do not have any validation at the schema-level in admithub-common, however, which means that theoretically, a bad phone number _could_ be saved to the database. Unsure how possible this really is because a bad phone number wouldn't really be able to text an open bot, but in any case, better safe than sorry.

This PR adds some simple validation to the `_phone` field in the `BrandedUserProfile` schema.

